### PR TITLE
Pass all commandline arguments to spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function main(args) {
     cwd: workingDir,
     stdio: 'inherit'
   }
-  var proc = spawn(electron, [script], spawnOpts);
+  var proc = spawn(electron, process.argv.slice(2), spawnOpts);
 
   proc.on('exit', function() {
     process.exit(0);
@@ -37,4 +37,3 @@ function main(args) {
     console.error(err.stack);
   });
 }
-


### PR DESCRIPTION
I don't think this is entirely the right solution, but I would like some mechanism to be able to pass arguments to the electron process. 

The main one I care about is `--require`, but it seems like there should be some way to pass any args through.